### PR TITLE
Migrate to Cobra for CLI, allow for multiple (concurrent) file transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Start the server
 go run server/main.go
 ```
 
-To send file(s) to the server, navigate to `client/` and run `go run main.go tcp-transfer <file_path(s)>`, `<file_paths` may be realtive or absolute. The file(s) will appear in the `server/transferred` directory once the transfer is complete. 
+To send file(s) to the server, navigate to `client/` and run `go run main.go tcp-transfer <file_path(s)>`, `<file_paths>` may be realtive or absolute. The file(s) will appear in the `server/transferred` directory once the transfer is complete. 
 
 ## The Custom Protocol
 A (simple) custom protocol was developed for this application. When a file is transferred, the following are sent (in order):

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Start the server
 go run server/main.go
 ```
 
-To send a file to the server, navigate to `client/` and run `go run transfer.go <file>`, or build the client ahead of time with `go build client/transfer.go`, then use `./transfer <file>`. 
-`<file>` can be either an absolute or relative path. The file will appear in the `server/transferred` directory once the transfer is complete.
+To send file(s) to the server, navigate to `client/` and run `go run main.go tcp-transfer <file_path(s)>`, `<file_paths` may be realtive or absolute. The file(s) will appear in the `server/transferred` directory once the transfer is complete. 
 
 ## The Custom Protocol
 A (simple) custom protocol was developed for this application. When a file is transferred, the following are sent (in order):

--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"file_trans/client/transfer"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+var cfgFile string
+var transferCmd = &cobra.Command{
+	Use:   "tcp-transfer [file(s)]",
+	Short: "tcp-transfer is a simple file transfer application",
+	Long:  `tcp-transfer is a simple CLI application that allows you to transfer files from a client to a specified server using TCP.`,
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Do stuff here
+		//fmt.Println(args[1])
+
+		var wg sync.WaitGroup
+		wg.Add(len(args))
+
+		for _, fileName := range args {
+			go transfer.TransferFile("localhost:8080", fileName, &wg)
+		}
+		wg.Wait()
+	},
+}
+
+func Execute() {
+	if err := transferCmd.Execute(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}
+
+func init() {
+
+	transferCmd.AddCommand()
+}

--- a/client/files/test.txt
+++ b/client/files/test.txt
@@ -1,0 +1,1 @@
+The Quick Brown Fox Jumps Over The Lazy Dog.

--- a/client/main.go
+++ b/client/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"file_trans/client/cmd"
+
+	"go.uber.org/zap"
+)
+
+var Logger *zap.Logger
+
+func main() {
+	cmd.Execute()
+	Logger, _ = zap.NewProduction()
+}

--- a/client/transfer/transfer.go
+++ b/client/transfer/transfer.go
@@ -1,4 +1,4 @@
-package main
+package transfer
 
 import (
 	"encoding/binary"
@@ -7,32 +7,27 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"go.uber.org/zap"
 )
 
-func main() {
-	args := os.Args
-	if len(args) != 2 {
-		fmt.Printf("Usage: transfer <file>\n")
-		os.Exit(2)
-	}
+var logger, err = zap.NewProduction()
 
-	logger, _ := zap.NewProduction()
-
-	fileName := args[1]
+func TransferFile(hostname, fileName string, wg *sync.WaitGroup) {
+	defer wg.Done()
 	file, err := os.Open(fileName)
 	if err != nil {
 		logger.Error("Could not open file: " + fileName)
 		return
 	}
+	defer file.Close()
+
 	baseFileName := filepath.Base(fileName)
 	fmt.Println("FILEPATH: ", baseFileName)
 
-	defer file.Close()
-
 	fmt.Println("Client Started!")
-	conn, err := net.Dial("tcp", "localhost:8080")
+	conn, err := net.Dial("tcp", hostname)
 
 	if err != nil {
 		logger.Error(err.Error())


### PR DESCRIPTION
This feature branch switches over to Cobra. The new syntax for our CLI is `tcp-transfer <file_path(s)>`. We now support concurrent file transfers via `goroutines`. 